### PR TITLE
Reduced restriction on sleep dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "i2c": "*",
-    "sleep": "~1.1.4"
+    "sleep": "*"
   },
   "keywords": [
     "PCF8574P",


### PR DESCRIPTION
Removed restriction on sleep dependency.

In the current npm package, the dependency on sleep package was too restrictive.  The version of sleep that was required appears to no longer build cleanly in modern node.js runtimes.
